### PR TITLE
Add whitespace blank line handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.14.5] - 2025-06-06
+
+### Fixed
+
+- **Whitespace Handling**: Collapsed blank lines containing spaces or tabs in
+  commit messages and prompt templates.
+
 ## [v0.14.4] - 2025-06-02
 
 ### Added

--- a/src/gac/__version__.py
+++ b/src/gac/__version__.py
@@ -1,3 +1,3 @@
 """Version information for gac package."""
 
-__version__ = "v0.14.4"
+__version__ = "v0.14.5"

--- a/src/gac/prompt.py
+++ b/src/gac/prompt.py
@@ -243,8 +243,8 @@ def build_prompt(
     else:
         template = re.sub(r"<one_liner>.*?</one_liner>", "", template, flags=re.DOTALL)
 
-    # Clean up extra whitespace
-    template = re.sub(r"\n{3,}", "\n\n", template)
+    # Clean up extra whitespace, collapsing blank lines that may contain spaces
+    template = re.sub(r"\n(?:[ \t]*\n){2,}", "\n\n", template)
 
     return template.strip()
 
@@ -355,6 +355,7 @@ def clean_commit_message(message: str) -> str:
         message = f"chore: {message.strip()}"
 
     # Final cleanup: trim extra whitespace and ensure no more than one blank line
-    message = re.sub(r"\n{3,}", "\n\n", message).strip()
+    # Handle blank lines that may include spaces or tabs
+    message = re.sub(r"\n(?:[ \t]*\n){2,}", "\n\n", message).strip()
 
     return message

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -112,6 +112,16 @@ class TestPrompts:
         result = clean_commit_message(message)
         assert result == "feat: Add new feature"
 
+        # Test collapse of multiple blank lines
+        message = "feat: Summary\n\n\nMore details after blank lines"
+        result = clean_commit_message(message)
+        assert result == "feat: Summary\n\nMore details after blank lines"
+
+        # Test collapse of blank lines containing spaces
+        message = "feat: Summary\n   \n \n\nMore details with spaces"
+        result = clean_commit_message(message)
+        assert result == "feat: Summary\n\nMore details with spaces"
+
         # Test message with code block markers
         message = "```\nfeat: Add new feature\n```"
         result = clean_commit_message(message)


### PR DESCRIPTION
## Summary
- handle spaces between blank lines in `clean_commit_message`
- update prompt template cleanup
- test collapsing of whitespace blank lines

## Testing
- `make test` *(fails: Request failed after 3 retries)*
- `pytest -k test_clean_commit_message -vv` *(fails: ModuleNotFoundError: No module named 'coverage')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_6843314f898c8333897d0855d730fad9